### PR TITLE
Use feedbackHandler instead of printing to console

### DIFF
--- a/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/OtlpHttpExporterBase.swift
@@ -8,6 +8,7 @@
 #endif
 import Foundation
 import SwiftProtobuf
+import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 #if canImport(FoundationNetworking)
   import FoundationNetworking
@@ -66,7 +67,7 @@ public class OtlpHttpExporterBase {
       // but it doesn't matter here
       request.httpBody = compressedData
     } catch {
-      print("Error serializing body: \(error)")
+      OpenTelemetry.instance.feedbackHandler?("Error serializing body: \(error)")
     }
 
     return request

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/StableOtlpHTTPExporterBase.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/StableOtlpHTTPExporterBase.swift
@@ -7,6 +7,7 @@
   import DataCompression
 #endif
 import Foundation
+import OpenTelemetryApi
 import OpenTelemetryProtocolExporterCommon
 import SwiftProtobuf
 #if canImport(FoundationNetworking)
@@ -77,7 +78,7 @@ public class StableOtlpHTTPExporterBase {
       // but it doesn't matter here
       request.httpBody = compressedData
     } catch {
-      print("Error serializing body: \(error)")
+      OpenTelemetry.instance.feedbackHandler?("Error serializing body: \(error)")
     }
     return request
   }

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/logs/OtlpHttpLogExporter.swift
@@ -68,7 +68,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter {
         self?.exporterLock.withLockVoid {
           self?.pendingLogRecords.append(contentsOf: sendingLogRecords)
         }
-        print(error)
+        OpenTelemetry.instance.feedbackHandler?(error.localizedDescription)
       }
     }
 
@@ -111,7 +111,7 @@ public class OtlpHttpLogExporter: OtlpHttpExporterBase, LogRecordExporter {
           exporterResult = ExportResult.success
         case let .failure(error):
           self?.exporterMetrics?.addFailed(value: pendingLogRecords.count)
-          print(error)
+        OpenTelemetry.instance.feedbackHandler?(error.localizedDescription)
           exporterResult = ExportResult.failure
         }
         semaphore.signal()

--- a/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
+++ b/Sources/Exporters/OpenTelemetryProtocolHttp/trace/OtlpHttpTraceExporter.swift
@@ -68,7 +68,7 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter {
         self?.exporterLock.withLockVoid {
           self?.pendingSpans.append(contentsOf: sendingSpans)
         }
-        print(error)
+        OpenTelemetry.instance.feedbackHandler?(error.localizedDescription)
       }
     }
     return .success
@@ -96,7 +96,7 @@ public class OtlpHttpTraceExporter: OtlpHttpExporterBase, SpanExporter {
           self?.exporterMetrics?.addSuccess(value: pendingSpans.count)
         case let .failure(error):
           self?.exporterMetrics?.addFailed(value: pendingSpans.count)
-          print(error)
+          OpenTelemetry.instance.feedbackHandler?(error.localizedDescription)
           resultValue = .failure
         }
         semaphore.signal()

--- a/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
+++ b/Sources/Instrumentation/SDKResourceExtension/DataSource/DeviceDataSource.swift
@@ -4,6 +4,7 @@
  */
 
 import Foundation
+import OpenTelemetryApi
 #if os(watchOS)
   import WatchKit
 #elseif os(macOS)
@@ -47,7 +48,7 @@ public class DeviceDataSource: IDeviceDataSource {
       let modelRequestError = sysctl(hwName, 2, machine, len, nil, 0)
       if modelRequestError != 0 {
         // TODO: better error log
-        print("error #\(errno): \(String(describing: String(utf8String: strerror(errno))))")
+        OpenTelemetry.instance.feedbackHandler?("error #\(errno): \(String(describing: String(utf8String: strerror(errno))))")
 
         return nil
       }

--- a/Sources/OpenTelemetryApi/Trace/Propagation/B3Propagator.swift
+++ b/Sources/OpenTelemetryApi/Trace/Propagation/B3Propagator.swift
@@ -60,7 +60,7 @@ public class B3Propagator: TextMapPropagator {
       spanContext = getSpanContextFromMultipleHeaders(carrier: carrier, getter: getter)
     }
     if spanContext == nil {
-      print("Invalid SpanId in B3 header. Returning no span context.")
+        OpenTelemetry.instance.feedbackHandler?("Invalid SpanId in B3 header. Returning no span context.")
     }
 
     return spanContext

--- a/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
+++ b/Sources/OpenTelemetrySdk/Trace/TracerProviderSdk.swift
@@ -40,7 +40,7 @@ public class TracerProviderSdk: TracerProvider {
     var instrumentationName = instrumentationName
     if instrumentationName.isEmpty {
       // Per the spec, empty is "invalid"
-      print("Tracer requested without instrumentation name.")
+      OpenTelemetry.instance.feedbackHandler?("Tracer requested without instrumentation name.")
       instrumentationName = TracerProviderSdk.emptyName
     }
     let instrumentationScopeInfo = InstrumentationScopeInfo(


### PR DESCRIPTION
`feedbackHandler` delegates printing back to the application, so it's worth using everywhere.