### PR TITLE
remove unused NetworkStatus and os_log dependency for context propagation

### DIFF
--- a/OpenTelemetry-Swift-Api.podspec
+++ b/OpenTelemetry-Swift-Api.podspec
@@ -59,6 +59,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'Notability' do |s|
     s.dependency 'OpenTelemetry-Swift-Api/Logs'
     s.dependency 'OpenTelemetry-Swift-Api/Trace'
+    s.dependency 'OpenTelemetry-Swift-Api/Propagation'
   end
 
 end

--- a/OpenTelemetry-Swift-SdkResourceExtension.podspec
+++ b/OpenTelemetry-Swift-SdkResourceExtension.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |spec|
   spec.module_name = "ResourceExtension"
 
   spec.subspec 'NetworkStatus' do |s|
-    s.dependency 'NetworkStatus' # 3rd party
     s.source_files = 'Sources/Instrumentation/NetworkStatus/**/*.swift'
   end
 

--- a/Sources/Instrumentation/URLSession/URLSessionLogger.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionLogger.swift
@@ -6,10 +6,6 @@
 import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
-import os.log
-#if os(iOS) && !targetEnvironment(macCatalyst)
-  import NetworkStatus
-#endif // os(iOS) && !targetEnvironment(macCatalyst)
 
 class URLSessionLogger {
   static var runningSpans = [String: Span]()
@@ -21,12 +17,7 @@ class URLSessionLogger {
         let netstats = try NetworkStatus()
         return NetworkStatusInjector(netstat: netstats)
       } catch {
-        if #available(iOS 14, macOS 11, tvOS 14, *) {
-          os_log(.error, "failed to initialize network connection status: %@", error.localizedDescription)
-        } else {
-          NSLog("failed to initialize network connection status: %@", error.localizedDescription)
-        }
-
+        OpenTelemetry.instance.feedbackHandler?("failed to initialize network connection status: \(error.localizedDescription)")
         return nil
       }
     }()


### PR DESCRIPTION
`NetworkStatus` isn't available on Mac and doesn't appear to be used by the library anyway? Also replace direct log with `feedbackHandler`