### PR TITLE
1.15.0.d

### DIFF
--- a/OpenTelemetry-Swift-PersistenceExporter.podspec
+++ b/OpenTelemetry-Swift-PersistenceExporter.podspec
@@ -1,0 +1,55 @@
+Pod::Spec.new do |spec|
+  spec.name = "OpenTelemetry-Swift-PersistenceExporter"
+  spec.version = "1.15.0"
+  spec.summary = "Swift OpenTelemetry Standard output Exporter"
+
+  spec.homepage = "https://github.com/open-telemetry/opentelemetry-swift"
+  spec.documentation_url = "https://opentelemetry.io/docs/languages/swift"
+  spec.license = { :type => "Apache 2.0", :file => "LICENSE" }
+  spec.authors = "OpenTelemetry Authors"
+
+  spec.source = { :git => "https://github.com/open-telemetry/opentelemetry-swift.git", :tag => spec.version.to_s }
+
+  spec.swift_version = "5.10"
+  spec.ios.deployment_target = "13.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.watchos.deployment_target = "6.0"
+  spec.module_name = "PersistenceExporter"
+
+  spec.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS" => "-module-name PersistenceExporter -package-name opentelemetry_swift_stdout_exporter" }
+
+  spec.subspec 'Core' do |s|
+    s.source_files = ['Sources/Exporters/Persistence/PersistenceExporterDecorator.swift',
+                      'Sources/Exporters/Persistence/PersistencePerformancePreset.swift',
+                      'Sources/Exporters/Persistence/Export/*.swift',
+                      'Sources/Exporters/Persistence/Storage/*.swift',
+                      'Sources/Exporters/Persistence/Utils/*.swift']
+  end
+
+  spec.subspec 'Logs' do |s|
+    s.dependency 'OpenTelemetry-Swift-Api/Logs'
+    s.dependency 'OpenTelemetry-Swift-Sdk/Logs'
+    s.dependency 'OpenTelemetry-Swift-PersistenceExporter/Core'
+    s.source_files = 'Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift'
+  end
+
+  spec.subspec 'Metrics' do |s|
+    s.dependency 'OpenTelemetry-Swift-Api/Metrics'
+    s.dependency 'OpenTelemetry-Swift-Sdk/Metrics'
+    s.dependency 'OpenTelemetry-Swift-PersistenceExporter/Core'
+    s.source_files = 'Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift'
+  end
+
+  spec.subspec 'Trace' do |s|
+    s.dependency 'OpenTelemetry-Swift-Api/Trace'
+    s.dependency 'OpenTelemetry-Swift-Sdk/Trace'
+    s.dependency 'OpenTelemetry-Swift-PersistenceExporter/Core'
+    s.source_files = 'Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift'
+  end
+
+  spec.subspec 'Notability' do |s|
+    s.dependency 'OpenTelemetry-Swift-PersistenceExporter/Logs'
+    s.dependency 'OpenTelemetry-Swift-PersistenceExporter/Trace'
+  end
+
+end

--- a/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceLogExporterDecorator.swift
@@ -18,9 +18,11 @@ public class PersistenceLogExporterDecorator: LogRecordExporter {
       self.logRecordExporter = logRecordExporter
     }
 
-    func export(values: [ReadableLogRecord]) -> DataExportStatus {
-      let result = logRecordExporter.export(logRecords: values)
-      return DataExportStatus(needsRetry: result == .failure)
+    func export(values: [ReadableLogRecord], completion: @escaping (DataExportStatus) -> Void) {
+      logRecordExporter.export(logRecords: values) { result in
+        let status = DataExportStatus(needsRetry: result == .failure)
+        completion(status)
+      }
     }
   }
 
@@ -39,6 +41,11 @@ public class PersistenceLogExporterDecorator: LogRecordExporter {
       exportCondition: exportCondition,
       performancePreset: performancePreset)
     self.logRecordExporter = logRecordExporter
+  }
+
+  public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?, completion: ((ExportResult) -> Void)?) {
+    let result = self.export(logRecords: logRecords, explicitTimeout: explicitTimeout)
+    completion?(result)
   }
 
   public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> ExportResult {

--- a/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceMetricExporterDecorator.swift
@@ -18,9 +18,9 @@ public class PersistenceMetricExporterDecorator: MetricExporter {
       self.metricExporter = metricExporter
     }
 
-    func export(values: [Metric]) -> DataExportStatus {
+    func export(values: [Metric], completion: @escaping (DataExportStatus) -> Void) {
       let result = metricExporter.export(metrics: values, shouldCancel: nil)
-      return DataExportStatus(needsRetry: result == .failureRetryable)
+      completion(DataExportStatus(needsRetry: result == .failureRetryable))
     }
   }
 

--- a/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
+++ b/Sources/Exporters/Persistence/PersistenceSpanExporterDecorator.swift
@@ -18,9 +18,10 @@ public class PersistenceSpanExporterDecorator: SpanExporter {
       self.spanExporter = spanExporter
     }
 
-    func export(values: [SpanData]) -> DataExportStatus {
-      _ = spanExporter.export(spans: values)
-      return DataExportStatus(needsRetry: false)
+    func export(values: [SpanData], completion: @escaping (DataExportStatus) -> Void) {
+      spanExporter.export(spans: values) { _ in
+        completion(DataExportStatus(needsRetry: false))
+      }
     }
   }
 
@@ -41,14 +42,13 @@ public class PersistenceSpanExporterDecorator: SpanExporter {
                                                           performancePreset: performancePreset)
   }
 
-  public func export(spans: [SpanData], explicitTimeout: TimeInterval?)
-    -> SpanExporterResultCode {
+  public func export(spans: [SpanData], explicitTimeout: TimeInterval?, completion: ((OpenTelemetrySdk.SpanExporterResultCode) -> Void)?) {
     do {
       try persistenceExporter.export(values: spans)
 
-      return .success
+      completion?(.success)
     } catch {
-      return .failure
+      completion?(.failure)
     }
   }
 

--- a/Sources/Exporters/Stdout/StdoutLogExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutLogExporter.swift
@@ -13,6 +13,11 @@ class StdoutLogExporter: LogRecordExporter {
     self.isDebug = isDebug
   }
 
+  func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval?, completion: ((OpenTelemetrySdk.ExportResult) -> Void)?) {
+    let result = self.export(logRecords: logRecords, explicitTimeout: explicitTimeout)
+    completion?(result)
+  }
+
   func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval?) -> OpenTelemetrySdk.ExportResult {
     if isDebug {
       for logRecord in logRecords {

--- a/Sources/Exporters/Stdout/StdoutSpanExporter.swift
+++ b/Sources/Exporters/Stdout/StdoutSpanExporter.swift
@@ -17,6 +17,11 @@ public class StdoutSpanExporter: SpanExporter {
     self.isDebug = isDebug
   }
 
+  public func export(spans: [SpanData], explicitTimeout: TimeInterval?, completion: ((SpanExporterResultCode) -> Void)?) {
+    let result = self.export(spans: spans, explicitTimeout: explicitTimeout)
+    completion?(result)
+  }
+
   public func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode {
     let jsonEncoder = JSONEncoder()
     for span in spans {

--- a/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
+++ b/Sources/Instrumentation/URLSession/URLSessionInstrumentation.swift
@@ -29,7 +29,7 @@ private var idKey: Void?
 public class URLSessionInstrumentation {
   private var requestMap = [String: NetworkRequestState]()
 
-  var configuration: URLSessionInstrumentationConfiguration
+  public var configuration: URLSessionInstrumentationConfiguration
 
   private let queue = DispatchQueue(
     label: "io.opentelemetry.ddnetworkinstrumentation")

--- a/Sources/OpenTelemetrySdk/Logs/Export/InMemoryLogRecordExporter.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Export/InMemoryLogRecordExporter.swift
@@ -13,6 +13,11 @@ public class InMemoryLogRecordExporter: LogRecordExporter {
     return finishedLogRecords
   }
 
+  public func export(logRecords: [OpenTelemetrySdk.ReadableLogRecord], explicitTimeout: TimeInterval?, completion: ((OpenTelemetrySdk.ExportResult) -> Void)?) {
+    let result = self.export(logRecords: logRecords, explicitTimeout: explicitTimeout)
+    completion?(result)
+  }
+
   public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> ExportResult {
     guard isRunning else {
       return .failure

--- a/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Export/LogRecordExporter.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 public protocol LogRecordExporter {
-  func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?) -> ExportResult
+  func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval?, completion: ((ExportResult) -> Void)?)
 
   /// Shutdown the log exporter
   ///
@@ -18,8 +18,8 @@ public protocol LogRecordExporter {
 }
 
 public extension LogRecordExporter {
-  func export(logRecords: [ReadableLogRecord]) -> ExportResult {
-    return export(logRecords: logRecords, explicitTimeout: nil)
+  func export(logRecords: [ReadableLogRecord], completion: ((ExportResult) -> Void)?) {
+    return export(logRecords: logRecords, explicitTimeout: nil, completion: completion)
   }
 
   func shutdown() {

--- a/Sources/OpenTelemetrySdk/Logs/Export/NoopLogRecordExporter.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Export/NoopLogRecordExporter.swift
@@ -8,8 +8,8 @@ import Foundation
 public class NoopLogRecordExporter: LogRecordExporter {
   public static let instance = NoopLogRecordExporter()
 
-  public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval? = nil) -> ExportResult {
-    .success
+  public func export(logRecords: [ReadableLogRecord], explicitTimeout: TimeInterval? = nil, completion: ((ExportResult) -> Void)?) {
+    completion?(.success)
   }
 
   public func shutdown(explicitTimeout: TimeInterval? = nil) {}

--- a/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Processors/BatchLogRecordProcessor.swift
@@ -132,7 +132,7 @@ private class BatchWorker: WorkerThread {
     stride(from: 0, to: logRecordList.endIndex, by: maxExportBatchSize).forEach {
       var logRecordToExport = logRecordList[$0 ..< min($0 + maxExportBatchSize, logRecordList.count)].map { $0 }
       willExportCallback?(&logRecordToExport)
-      _ = logRecordExporter.export(logRecords: logRecordToExport, explicitTimeout: explicitTimeout)
+      logRecordExporter.export(logRecords: logRecordToExport, explicitTimeout: explicitTimeout, completion: nil)
     }
   }
 }

--- a/Sources/OpenTelemetrySdk/Logs/Processors/SimpleLogRecordProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Logs/Processors/SimpleLogRecordProcessor.swift
@@ -13,7 +13,7 @@ public class SimpleLogRecordProcessor: LogRecordProcessor {
   }
 
   public func onEmit(logRecord: ReadableLogRecord) {
-    _ = logRecordExporter.export(logRecords: [logRecord], explicitTimeout: nil)
+    logRecordExporter.export(logRecords: [logRecord], explicitTimeout: nil, completion: nil)
   }
 
   public func forceFlush(explicitTimeout: TimeInterval? = nil) -> ExportResult {

--- a/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/MultiSpanExporter.swift
@@ -16,12 +16,23 @@ public class MultiSpanExporter: SpanExporter {
     self.spanExporters = spanExporters
   }
 
-  public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {
-    var currentResultCode = SpanExporterResultCode.success
-    for exporter in spanExporters {
-      currentResultCode.mergeResultCode(newResultCode: exporter.export(spans: spans, explicitTimeout: explicitTimeout))
-    }
-    return currentResultCode
+  public func export(spans: [SpanData], explicitTimeout: TimeInterval? = nil, completion: ((SpanExporterResultCode) -> Void)?) {
+      Task {
+          var currentResultCode = SpanExporterResultCode.success
+          await withTaskGroup { group in
+              spanExporters.forEach { exporter in
+                  group.addTask {
+                      let newResult = await withCheckedContinuation { continuation in
+                          exporter.export(spans: spans, explicitTimeout: explicitTimeout) { result in
+                              continuation.resume(returning: result)
+                          }
+                      }
+                      currentResultCode.mergeResultCode(newResultCode: newResult)
+                  }
+              }
+          }
+          completion?(currentResultCode)
+      }
   }
 
   public func flush(explicitTimeout: TimeInterval? = nil) -> SpanExporterResultCode {

--- a/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift
+++ b/Sources/OpenTelemetrySdk/Trace/Export/SpanExporter.swift
@@ -12,7 +12,7 @@ import Foundation
 public protocol SpanExporter: AnyObject {
   /// Called to export sampled Spans.
   /// - Parameter spans: the list of sampled Spans to be exported.
-  @discardableResult func export(spans: [SpanData], explicitTimeout: TimeInterval?) -> SpanExporterResultCode
+  func export(spans: [SpanData], explicitTimeout: TimeInterval?, completion: ((SpanExporterResultCode) -> Void)?)
 
   /// Exports the collection of sampled Spans that have not yet been exported.
   func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode
@@ -23,8 +23,8 @@ public protocol SpanExporter: AnyObject {
 }
 
 public extension SpanExporter {
-  func export(spans: [SpanData]) -> SpanExporterResultCode {
-    return export(spans: spans, explicitTimeout: nil)
+  func export(spans: [SpanData], completion: ((SpanExporterResultCode) -> Void)?) {
+    return export(spans: spans, explicitTimeout: nil, completion: completion)
   }
 
   func flush() -> SpanExporterResultCode {

--- a/Sources/OpenTelemetrySdk/Trace/SpanProcessors/SimpleSpanProcessor.swift
+++ b/Sources/OpenTelemetrySdk/Trace/SpanProcessors/SimpleSpanProcessor.swift
@@ -26,7 +26,7 @@ public struct SimpleSpanProcessor: SpanProcessor {
     let span = span.toSpanData()
     let spanExporterAux = spanExporter
     processorQueue.async {
-      _ = spanExporterAux.export(spans: [span])
+      spanExporterAux.export(spans: [span], completion: nil)
     }
   }
 


### PR DESCRIPTION
1. Make `URLSessionInstrumentationConfiguration` public so the closures (eg `shouldInstrument`) can be updated after init
2. Add a podspec to allow access to the (buggy) PersistenceExporter in case we want to use the library for local persistence
3. exporters can be async, so report results in completion instead of direct return value