### PR TITLE
Don't re-export in-flight batches (fixes duplicate log exports)

### DIFF
--- a/Sources/Exporters/Persistence/Export/DataExportWorker.swift
+++ b/Sources/Exporters/Persistence/Export/DataExportWorker.swift
@@ -60,12 +60,15 @@ class DataExportWorker: DataExportWorkerProtocol {
             self.fileReader.markBatchAsRead(batch)
             self.delay.decrease()
           }
+
+          // Reschedule only after this export completes — avoids re-reading the
+          // in-flight file which may lead to sending duplicates to the collector
+          self.scheduleNextExport(after: self.delay.current)
         }
       } else {
         self.delay.increase()
+        self.scheduleNextExport(after: self.delay.current)
       }
-
-      scheduleNextExport(after: self.delay.current)
     }
 
     self.exportWork = exportWork


### PR DESCRIPTION
Fixes a duplicate-export regression in the persistence `DataExportWorker`.

## Problem

`DataExportWorker` scheduled the next run **synchronously**, immediately after firing the async export:

```swift
self.dataExporter.export(data: batch.data) { exportStatus in
  if exportStatus.needsRetry { delay.increase() }
  else { fileReader.markBatchAsRead(batch); delay.decrease() }
}
scheduleNextExport(after: self.delay.current)   // runs before the export above completes
```

`readNextBatch()` excludes only files already marked read (`filesRead`), and a file is marked read / deleted in the export **completion**. So while an export is in flight, the next tick re-reads the *same* not-yet-deleted file and exports it again — repeatedly, every `minExportDelay` (1s floor), until the first attempt finally returns. With any real network latency this re-sends a single batch many times.

Observed in production as dense bursts of records sharing one client-generated `log.uuid` (the uuid is generated once per emission), e.g. a single uuid ingested **2,295×** within one window — all identical in body and attributes. Note that dupes currently count for 8-10% of our Honeycomb traffic!

This is a regression from `d9948a4de` ("async results for failable http export"), which converted the export chain to async completions but left `scheduleNextExport` firing eagerly. This problem only exists in our fork since upstream opentelemetry-swift exports synchronously.

## Verification

* I had Claude repro and then verify the fix with the GLTelemetry module code pinned to this branch. This was throwaway
* Claude wrote a bunch of tests to add to this repo. I can merge if we want but a couple of notes:
  * it had to touch some shared helpers for the tests
  * there are already a bunch of broken unit tests in the repo because they don't work with async. So it would not be possible to run the suite. 
  
 Let me know if y'all think it's still worth adding them. Another possibility: if we think this is going to be a long lived fork, we could also do a followup Claude driven fix of all of the unit tests.

## Follow-up (not in this PR)

Once this PR is merged, we can update Notability to point to the commit with a simple Swift Package Manager update.

I don't think there's a good way to devQA this (other than to have your own Claude instance do some testing), so leaving that to the follow up PR.
