### PR TITLE
Remove Linux-only swift-atomics dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,15 +21,13 @@ let package = Package(name: "opentelemetry-swift",
                       ],
                       dependencies: [
                         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.20.2"),
-                        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
-                        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0")
+                        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4")
                       ],
                       targets: [
                         .target(name: "OpenTelemetryApi",
                                 dependencies: []),
                         .target(name: "OpenTelemetrySdk",
-                                dependencies: ["OpenTelemetryApi",
-                                               .product(name: "Atomics", package: "swift-atomics", condition: .when(platforms: [.linux]))]),
+                                dependencies: ["OpenTelemetryApi"]),
                         .target(name: "OpenTelemetryTestUtils",
                                 dependencies: ["OpenTelemetryApi", "OpenTelemetrySdk"]),
                         .target(name: "OpenTelemetryProtocolExporterCommon",


### PR DESCRIPTION
## What

Drops the `swift-atomics` package dependency and the conditional `Atomics` product ref on the `OpenTelemetrySdk` target.

## Why

`OpenTelemetrySdk` only imports `Atomics` under `#if !canImport(Darwin)`, and the dependency was already gated to `.when(platforms: [.linux])`. On Apple platforms the product is never linked — but SwiftPM still resolves and checks out `swift-atomics`, and Xcode emits a note for every target that transitively depends on `OpenTelemetrySdk`:

> Skipping 'Atomics' because its platform filter (linux-gnu) does not match the platform filter of the current context (ios).

In the Notability app this surfaces as `Skipping '…/Atomics' … (in target 'GLAnalytics')` plus a `Skipping target dependency '(null)' … (linux-gnu)` note on `OpenTelemetrySdk`, `PersistenceExporter`, `ResourceExtension`, `StdoutExporter`, and the OTLP HTTP exporter targets.

## Effect

Removes the extra `swift-atomics` checkout and silences all of those platform-filter notes. No behavior change on Apple platforms (Atomics was never linked there).

## Tradeoff

This drops Linux atomics support. This fork is built only for Apple platforms, so that's intentional — but if a Linux build is ever needed, the dependency and the `#if !canImport(Darwin)` import in `RegisteredReader.swift` would both need to come back.

## Follow-up (consumer side)

The Notability app pins tag `1.15.0g` (== the current head of this `1.15.0f` branch). After this merges, cut a new tag from `1.15.0f` and bump the app's package reference to pick up the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)